### PR TITLE
@FIR-143: Enable HPS bridge by default

### DIFF
--- a/include/configs/socfpga_soc64_common.h
+++ b/include/configs/socfpga_soc64_common.h
@@ -170,7 +170,7 @@
 	"nandfitboot=setenv bootargs " CONFIG_BOOTARGS \
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
-	"nandfitload=ubi part root; ubi readvol ${loadaddr} kernel\0" \
+	"nandfitload=enable bridge 7; ubi part root; ubi readvol ${loadaddr} kernel\0" \
 	"socfpga_legacy_reset_compat=1\0" \
 	"rsu_status=rsu dtb; rsu display_dcmf_version; "\
 		"rsu display_dcmf_status; rsu display_max_retry\0" \
@@ -209,7 +209,7 @@
 	"nandfitboot=setenv bootargs " CONFIG_BOOTARGS \
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
-	"nandfitload=ubi part root; ubi readvol ${loadaddr} kernel\0" \
+	"nandfitload=bridge enable 7; ubi part root; ubi readvol ${loadaddr} kernel\0" \
 	"socfpga_legacy_reset_compat=1\0" \
 	"rsu_status=rsu dtb; rsu display_dcmf_version; "\
 		"rsu display_dcmf_status; rsu display_max_retry\0" \
@@ -275,7 +275,7 @@
 	"nandfitboot=setenv bootargs " CONFIG_BOOTARGS \
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
-	"nandfitload=ubi part root; ubi readvol ${loadaddr} kernel\0" \
+	"nandfitload=enable bridge 7; ubi part root; ubi readvol ${loadaddr} kernel\0" \
 	"socfpga_legacy_reset_compat=1\0" \
 	"rsu_status=rsu dtb; rsu display_dcmf_version; "\
 		"rsu display_dcmf_status; rsu display_max_retry\0" \


### PR DESCRIPTION
When the u-boot loads linux image in the linux command line to load linux using "run nandfitload" command add a command to enable hps bridge as well to turn on PCI-E accesses
-------------------------------------------------------------------------------------------

Description: Enable HPS Bridge enable by default for PCI-E access

Impact Analysis:

    What is the scope of the change?
When the u-boot loads linux image in the linux command line to load linux using "run nandfitload" command add a command to enable hps bridge as well to turn on PCI-E accesses

    Purpose of the change?
    To set bridge enable

    Reach of the change?
    Imaacts bittware FPGA

Regression Test result: <Regtest result link .>

Tested with bittware FPGA

Regression Test result: <Regtest result link .>
