### PR TITLE
@FIR-265: Added default command line to have run nandfitload/nandfitboot

### DIFF
--- a/include/configs/socfpga_soc64_common.h
+++ b/include/configs/socfpga_soc64_common.h
@@ -171,6 +171,7 @@
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
 	"nandfitload=enable bridge 7; ubi part root; ubi readvol ${loadaddr} kernel\0" \
+	"bootcmd=run nandfitload; run nandfitboot; " \
 	"socfpga_legacy_reset_compat=1\0" \
 	"rsu_status=rsu dtb; rsu display_dcmf_version; "\
 		"rsu display_dcmf_status; rsu display_max_retry\0" \
@@ -210,6 +211,7 @@
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
 	"nandfitload=bridge enable 7; ubi part root; ubi readvol ${loadaddr} kernel\0" \
+	"bootcmd=run nandfitload; run nandfitboot; " \
 	"socfpga_legacy_reset_compat=1\0" \
 	"rsu_status=rsu dtb; rsu display_dcmf_version; "\
 		"rsu display_dcmf_status; rsu display_max_retry\0" \
@@ -276,6 +278,7 @@
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
 	"nandfitload=enable bridge 7; ubi part root; ubi readvol ${loadaddr} kernel\0" \
+	"bootcmd=run nandfitload; run nandfitboot; " \
 	"socfpga_legacy_reset_compat=1\0" \
 	"rsu_status=rsu dtb; rsu display_dcmf_version; "\
 		"rsu display_dcmf_status; rsu display_max_retry\0" \


### PR DESCRIPTION
Tested the changes on FPGA1 and FPGA2 and the system boots using boot as follows

SOCFPGA_AGILEX7 # 
SOCFPGA_AGILEX7 # boot
UBI partition 'root' already selected
No size specified -> Using max size (25268224)
Read 25268224 bytes from volume kernel to 0000000002000000
## Loading kernel from FIT Image at 02000000 ...
   Using 'conf' configuration
   Verifying Hash Integrity ... OK
   Trying 'kernel' kernel subimage
     Description:  Linux Kernel
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x02000148
     Data Size:    9978473 Bytes = 9.5 MiB
     Architecture: AArch64
     OS:           Linux

