### PR TITLE
@FIR-538: Updated DTSI to add full 1GB reserved memory

### DIFF
--- a/arch/arm/dts/socfpga_agilex.dtsi
+++ b/arch/arm/dts/socfpga_agilex.dtsi
@@ -28,8 +28,7 @@
                         compatible = "shared-dma-pool";
                         reg = <0x0 0x40000000 0x0 0x40000000>;
                         alignment = <0x1000>;
-                        /*no-map;*/
-			reuseable;
+			reusable;
                 };
                service_reserved2: svcbuffer@2 {
                         compatible = "shared-dma-pool";

--- a/include/configs/socfpga_soc64_common.h
+++ b/include/configs/socfpga_soc64_common.h
@@ -149,6 +149,7 @@
 	"scriptsize=0x00010000\0" \
 	"qspibootimageaddr=0x02120000\0" \
 	"bootimagesize=0x03200000\0" \
+        "fdt_high=0x3F000000\0" \
 	"loadaddr=" __stringify(CONFIG_SYS_LOAD_ADDR) "\0" \
 	"bootfile=" CONFIG_BOOTFILE "\0" \
 	"mmcroot=/dev/mmcblk0p2\0" \
@@ -191,6 +192,7 @@
 	"bootimagesize=0x03200000\0" \
 	"loadaddr=" __stringify(CONFIG_SYS_LOAD_ADDR) "\0" \
 	"bootfile=" CONFIG_BOOTFILE "\0" \
+	"fdt_high=0x3F000000\0" \
 	"mmcroot=/dev/mmcblk0p2\0" \
 	"mtdids=" CONFIG_MTDIDS_DEFAULT "\0" \
 	"mtdparts=" CONFIG_MTDPARTS_DEFAULT "\0" \
@@ -240,6 +242,7 @@
 	"loadaddr=" __stringify(CONFIG_SYS_LOAD_ADDR) "\0" \
 	"bootfile=" CONFIG_BOOTFILE "\0" \
 	"fdt_addr=8000000\0" \
+	"fdt_high=0x3F000000\0" \
 	"fdtimage=" CONFIG_DEFAULT_DEVICE_TREE ".dtb\0" \
 	"mmcroot=/dev/mmcblk0p2\0" \
 	"mmcboot=setenv bootargs " CONFIG_BOOTARGS \


### PR DESCRIPTION
This change has following
1. DTSI file update to make the 1GB area reusable
2. Config environment variable for fdt_high to limit fdt load to be in 1GB

This change ensures that the device tree is always loaded in the first 1GB instead of going to higher 1GB in 2GB DDR>

