### PR TITLE
@FIR-712: Updating Baudrate for Console to 921600

### DIFF
--- a/arch/arm/dts/socfpga_agilex7m_socdk-u-boot.dtsi
+++ b/arch/arm/dts/socfpga_agilex7m_socdk-u-boot.dtsi
@@ -9,7 +9,7 @@
 
 /{
 	chosen {
-		stdout-path = "serial0:115200n8";
+		stdout-path = "serial0:921600n8";
 		u-boot,spl-boot-order = &mmc,&nand;
 	};
 

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -17,7 +17,7 @@ if SERIAL
 
 config BAUDRATE
 	int "Default baudrate"
-	default 115200
+	default 921600
 	help
 	  Select a default baudrate, where "default" has a driver-specific
 	  meaning of either setting the baudrate for the early debug UART


### PR DESCRIPTION
Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.

-------------------------------------------------------------------------------------------

Description: Change default baudrate to 921600

Impact Analysis:

    What is the scope of the change?
Serial Console

    Purpose of the change?
Serial Console's default baudrate to 921600

    Reach of the change?
Serial Console

Regression Test result: 
The change sets the default console baudrate to 921600 Following are the the test results
Terminating...
Thanks for using picocom
atrivedi@fpga2:/proj/work2/atrivedi/workspace/05_27_2025/tsi_yocto_workspace$ picocom -b 921600 /dev/ttyUSB3 picocom v3.1

port is        : /dev/ttyUSB3
flowcontrol    : none
baudrate is    : 921600
parity is      : none
databits are   : 8
stopbits are   : 1
escape is      : C-a
local echo is  : no
noinit is      : no
noreset is     : no
hangup is      : no
nolock is      : no
send_cmd is    : sz -vv
receive_cmd is : rz -vv -E
imap is        :
omap is        :
emap is        : crcrlf,delbs,
logfile is     : none
initstring     : none
exit_after is  : not set
exit is        : no

Type [C-a] [C-h] to see available commands
Terminal ready
���������������������������������������������������� U-Boot 2023.07-rc6-g903721c3 (May 30 2025 - 14:10:10 -0700)socfpga_agilex7

CPU:   Intel FPGA SoCFPGA Platform (ARMv8 64bit Cortex-A53)
Model: BittWare Agilex-7M
DRAM:  2 GiB
Core:  27 devices, 20 uclasses, devicetree: separate
Warning: Device tree includes old 'u-boot,dm-' tags: please fix by 2023.07!
NAND:  512 MiB
MMC:   dwmmc0@ff808000: 0
Loading Environment from UBI... Read 8192 bytes from volume env to 000000007faec9c0
*** Warning - bad CRC, using default environment

In:    serial0@ffc02000
Out:   serial0@ffc02000
Err:   serial0@ffc02000
Net:   No ethernet found.
SOCFPGA_AGILEX7 # boot
UBI partition 'root' already selected
No size specified -> Using max size (25268224)
Read 25268224 bytes from volume kernel to 0000000002000000
   Using 'conf' configuration
   Verifying Hash Integrity ... OK
   Trying 'kernel' kernel subimage
     Description:  Linux Kernel
     Type:         Kernel Image
     Compression:  lzma compressed
     Data Start:   0x02000148
     Data Size:    9815023 Bytes = 9.4 MiB
     Architecture: AArch64
     OS:           Linux
     Load Address: 0x06000000
     Entry Point:  0x06000000
     Hash algo:    crc32
     Hash value:   16fb6a5d
   Verifying Hash Integrity ... crc32+ OK
   Using 'conf' configuration
   Verifying Hash Integrity ... OK
   Trying 'fdt' fdt subimage
     Description:  Linux DTB
     Type:         Flat Device Tree
     Compression:  uncompressed
     Data Start:   0x0295c5d8
     Data Size:    23690 Bytes = 23.1 KiB
     Architecture: AArch64
     Hash algo:    crc32
     Hash value:   fa230350
   Verifying Hash Integrity ... crc32+ OK
   Booting using the fdt blob at 0x295c5d8
Working FDT set to 295c5d8
   Uncompressing Kernel Image
ERROR: reserving fdt memory region failed (addr=40000000 size=40000000 flags=0)
   Loading Device Tree to 000000003eff7000, end 000000003efffc89 ... OK
Working FDT set to 3eff7000

Starting kernel ...

[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.6.51-gfdb8e17d9312 (atrivedi@fpga2.tsavoritesi.net) (aarch64-none-linux-gnu-gcc (Arm GNU Toolchain 14.2.Rel1 (Build arm-14.52)) 14.2.1 20241119, GNU ld (Arm GNU Toolchain 14.2.Rel1 (Build arm-14.52)) 2.43.1.20241119) #1 SMP PREEMPT Fri May 30 14:07:30 PDT 2025
[    0.000000] KASLR disabled due to lack of seed
[    0.000000] Machine model: SoCFPGA Agilex BittWare
[    0.000000] efi: UEFI not found.
[    0.000000] Reserved memory: created DMA memory pool at 0x0000000000000000, size 32 MiB
[    0.000000] OF: reserved mem: initialized node svcbuffer@0, compatible id shared-dma-pool
[    0.000000] OF: reserved mem: 0x0000000000000000..0x0000000001ffffff (32768 KiB) nomap non-reusable svcbuffer@0
[    0.000000] Reserved memory: created CMA memory pool at 0x0000000040000000, size 1024 MiB
[    0.000000] OF: reserved mem: initialized node svcbuffer@1, compatible id shared-dma-pool
[    0.000000] OF: reserved mem: 0x0000000040000000..0x000000007fffffff (1048576 KiB) map reusable svcbuffer@1
[    0.000000] Reserved memory: created DMA memory pool at 0x0000002080000000, size 2048 MiB
[    0.000000] OF: reserved mem: initialized node svcbuffer@2, compatible id shared-dma-pool
[    0.000000] OF: reserved mem: 0x0000002080000000..0x00000020ffffffff (2097152 KiB) map non-reusable svcbuffer@2
[    0.000000] earlycon: uart0 at MMIO32 0x00000000ffc02000 (options '921600n8')
[    0.000000] printk: bootconsole [uart0] enabled
[    0.000000] NUMA: No NUMA configuration found
[    0.000000] NUMA: Faking a node at [mem 0x0000000000000000-0x000000007fffffff]
[    0.000000] NUMA: NODE_DATA [mem 0x3fbec9c0-0x3fbeefff]
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000000000000-0x000000007fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000001ffffff]
[    0.000000]   node   0: [mem 0x0000000002000000-0x000000007fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000007fffffff]
[    0.000000] cma: Reserved 16 MiB at 0x000000003be00000 on node -1
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.4
[    0.000000] percpu: Embedded 22 pages/cpu s50920 r8192 d31000 u90112
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: ARM erratum 845719
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: earlycon panic=-1 root=ubi0:rootfs rw rootwait rootfstype=ubifs ubi.mtd=1
[    0.000000] Dentry cache hash table entries: 262144 (order: 9, 2097152 bytes, linear)
[    0.000000] Inode-cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
[    0.000000] Fallback order for Node 0: 0
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 516096
[    0.000000] Policy zone: DMA
[    0.000000] mem auto-init: stack:all(zero), heap alloc:off, heap free:off
[    0.000000] software IO TLB: area num 4.
[    0.000000] software IO TLB: mapped [mem 0x0000000037e00000-0x000000003be00000] (64MB)
[    0.000000] Memory: 856636K/2097152K available (17536K kernel code, 4284K rwdata, 10768K rodata, 2688K init, 608K bss, 175556K reserved, 1064960K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Preemptible hierarchical RCU implementation.
[    0.000000] rcu: 	RCU event tracing is enabled.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=256 to nr_cpu_ids=4.
[    0.000000] 	Trampoline variant of Tasks RCU enabled.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GIC: Using split EOI/Deactivate mode
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 400.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0x7ffffffffffffff max_cycles: 0x5c4093a7d1, max_idle_ns: 440795210635 ns
[    0.000001] sched_clock: 59 bits at 400MHz, resolution 2ns, wraps every 4398046511103ns
[    0.002254] Console: colour dummy device 80x25
[    0.002918] printk: console [tty0] enabled
[    0.003529] printk: bootconsole [uart0] disabled
[    0.000000] Booting Linux on physical CPU 0x0000000000 [0x410fd034]
[    0.000000] Linux version 6.6.51-gfdb8e17d9312 (atrivedi@fpga2.tsavoritesi.net) (aarch64-none-linux-gnu-gcc (Arm GNU Toolchain 14.2.Rel1 (Build arm-14.52)) 14.2.1 20241119, GNU ld (Arm GNU Toolchain 14.2.Rel1 (Build arm-14.52)) 2.43.1.20241119) #1 SMP PREEMPT Fri May 30 14:07:30 PDT 2025
[    0.000000] KASLR disabled due to lack of seed
[    0.000000] Machine model: SoCFPGA Agilex BittWare
[    0.000000] efi: UEFI not found.
[    0.000000] Reserved memory: created DMA memory pool at 0x0000000000000000, size 32 MiB
[    0.000000] OF: reserved mem: initialized node svcbuffer@0, compatible id shared-dma-pool
[    0.000000] OF: reserved mem: 0x0000000000000000..0x0000000001ffffff (32768 KiB) nomap non-reusable svcbuffer@0
[    0.000000] Reserved memory: created CMA memory pool at 0x0000000040000000, size 1024 MiB
[    0.000000] OF: reserved mem: initialized node svcbuffer@1, compatible id shared-dma-pool
[    0.000000] OF: reserved mem: 0x0000000040000000..0x000000007fffffff (1048576 KiB) map reusable svcbuffer@1
[    0.000000] Reserved memory: created DMA memory pool at 0x0000002080000000, size 2048 MiB
[    0.000000] OF: reserved mem: initialized node svcbuffer@2, compatible id shared-dma-pool
[    0.000000] OF: reserved mem: 0x0000002080000000..0x00000020ffffffff (2097152 KiB) map non-reusable svcbuffer@2
[    0.000000] earlycon: uart0 at MMIO32 0x00000000ffc02000 (options '921600n8')
[    0.000000] printk: bootconsole [uart0] enabled
[    0.000000] NUMA: No NUMA configuration found
[    0.000000] NUMA: Faking a node at [mem 0x0000000000000000-0x000000007fffffff]
[    0.000000] NUMA: NODE_DATA [mem 0x3fbec9c0-0x3fbeefff]
[    0.000000] Zone ranges:
[    0.000000]   DMA      [mem 0x0000000000000000-0x000000007fffffff]
[    0.000000]   DMA32    empty
[    0.000000]   Normal   empty
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000001ffffff]
[    0.000000]   node   0: [mem 0x0000000002000000-0x000000007fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000007fffffff]
[    0.000000] cma: Reserved 16 MiB at 0x000000003be00000 on node -1
[    0.000000] psci: probing for conduit method from DT.
[    0.000000] psci: PSCIv1.1 detected in firmware.
[    0.000000] psci: Using standard PSCI v0.2 function IDs
[    0.000000] psci: MIGRATE_INFO_TYPE not supported.
[    0.000000] psci: SMC Calling Convention v1.4
[    0.000000] percpu: Embedded 22 pages/cpu s50920 r8192 d31000 u90112
[    0.000000] Detected VIPT I-cache on CPU0
[    0.000000] CPU features: detected: ARM erratum 845719
[    0.000000] alternatives: applying boot alternatives
[    0.000000] Kernel command line: earlycon panic=-1 root=ubi0:rootfs rw rootwait rootfstype=ubifs ubi.mtd=1
[    0.000000] Dentry cache hash table entries: 262144 (order: 9, 2097152 bytes, linear)
[    0.000000] Inode-cache hash table entries: 131072 (order: 8, 1048576 bytes, linear)
[    0.000000] Fallback order for Node 0: 0
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 516096
[    0.000000] Policy zone: DMA
[    0.000000] mem auto-init: stack:all(zero), heap alloc:off, heap free:off
[    0.000000] software IO TLB: area num 4.
[    0.000000] software IO TLB: mapped [mem 0x0000000037e00000-0x000000003be00000] (64MB)
[    0.000000] Memory: 856636K/2097152K available (17536K kernel code, 4284K rwdata, 10768K rodata, 2688K init, 608K bss, 175556K reserved, 1064960K cma-reserved)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] rcu: Preemptible hierarchical RCU implementation.
[    0.000000] rcu: 	RCU event tracing is enabled.
[    0.000000] rcu: 	RCU restricting CPUs from NR_CPUS=256 to nr_cpu_ids=4.
[    0.000000] 	Trampoline variant of Tasks RCU enabled.
[    0.000000] 	Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 25 jiffies.
[    0.000000] rcu: Adjusting geometry for rcu_fanout_leaf=16, nr_cpu_ids=4
[    0.000000] NR_IRQS: 64, nr_irqs: 64, preallocated irqs: 0
[    0.000000] Root IRQ handler: gic_handle_irq
[    0.000000] GIC: Using split EOI/Deactivate mode
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 timer(s) running at 400.00MHz (phys).
[    0.000000] clocksource: arch_sys_counter: mask: 0x7ffffffffffffff max_cycles: 0x5c4093a7d1, max_idle_ns: 440795210635 ns
[    0.000001] sched_clock: 59 bits at 400MHz, resolution 2ns, wraps every 4398046511103ns
[    0.002254] Console: colour dummy device 80x25
[    0.002918] printk: console [tty0] enabled
[    0.003529] printk: bootconsole [uart0] disabled
[    0.004324] Calibrating delay loop (skipped), value calculated using timer frequency.. 800.00 BogoMIPS (lpj=1600000)
[    0.004350] pid_max: default: 32768 minimum: 301
[    0.004444] LSM: initializing lsm=capability,integrity
[    0.004576] Mount-cache hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.004601] Mountpoint-cache hash table entries: 4096 (order: 3, 32768 bytes, linear)
[    0.005863] cacheinfo: Unable to detect cache hierarchy for CPU 0
[    0.006696] RCU Tasks: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1.
[    0.006773] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1.
[    0.006998] rcu: Hierarchical SRCU implementation.
[    0.007010] rcu: 	Max phase no-delay instances is 1000.
[    0.008441] EFI services will not be available.
[    0.008671] smp: Bringing up secondary CPUs ...
[    0.009249] Detected VIPT I-cache on CPU1
[    0.009357] CPU1: Booted secondary processor 0x0000000001 [0x410fd034]
[    0.009971] Detected VIPT I-cache on CPU2
[    0.010015] CPU2: Booted secondary processor 0x0000000002 [0x410fd034]
[    0.010571] Detected VIPT I-cache on CPU3
[    0.010610] CPU3: Booted secondary processor 0x0000000003 [0x410fd034]
[    0.010677] smp: Brought up 1 node, 4 CPUs
[    0.010729] SMP: Total of 4 processors activated.
[    0.010741] CPU features: detected: 32-bit EL0 Support
[    0.010752] CPU features: detected: 32-bit EL1 Support
[    0.010764] CPU features: detected: CRC32 instructions
[    0.010853] CPU: All CPU(s) started at EL2
[    0.010890] alternatives: applying system-wide alternatives
[    0.014098] devtmpfs: initialized
[    0.019165] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 7645041785100000 ns
[    0.019206] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.062594] pinctrl core: initialized pinctrl subsystem
[    0.064565] DMI not present or invalid.
[    0.065446] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.066882] DMA: preallocated 256 KiB GFP_KERNEL pool for atomic allocations
[    0.067088] DMA: preallocated 256 KiB GFP_KERNEL|GFP_DMA pool for atomic allocations
[    0.067287] DMA: preallocated 256 KiB GFP_KERNEL|GFP_DMA32 pool for atomic allocations
[    0.067345] audit: initializing netlink subsys (disabled)
[    0.067507] audit: type=2000 audit(0.068:1): state=initialized audit_enabled=0 res=1
[    0.068706] thermal_sys: Registered thermal governor 'step_wise'
[    0.068713] thermal_sys: Registered thermal governor 'power_allocator'
[    0.068779] cpuidle: using governor menu
[    0.069003] hw-breakpoint: found 6 breakpoint and 4 watchpoint registers.
[    0.069112] ASID allocator initialised with 65536 entries
[    0.071084] Serial: AMBA PL011 UART driver
[    0.085378] Modules: 23744 pages in range for non-PLT usage
[    0.085396] Modules: 515264 pages in range for PLT usage
[    0.086303] HugeTLB: registered 1.00 GiB page size, pre-allocated 0 pages
[    0.086333] HugeTLB: 0 KiB vmemmap can be freed for a 1.00 GiB page
[    0.086348] HugeTLB: registered 32.0 MiB page size, pre-allocated 0 pages
[    0.086360] HugeTLB: 0 KiB vmemmap can be freed for a 32.0 MiB page
[    0.086372] HugeTLB: registered 2.00 MiB page size, pre-allocated 0 pages
[    0.086384] HugeTLB: 0 KiB vmemmap can be freed for a 2.00 MiB page
[    0.086397] HugeTLB: registered 64.0 KiB page size, pre-allocated 0 pages
[    0.086408] HugeTLB: 0 KiB vmemmap can be freed for a 64.0 KiB page
[    0.088414] ACPI: Interpreter disabled.
[    0.090461] iommu: Default domain type: Translated
[    0.090476] iommu: DMA domain TLB invalidation policy: strict mode
[    0.090808] SCSI subsystem initialized
[    0.091223] usbcore: registered new interface driver usbfs
[    0.091268] usbcore: registered new interface driver hub
[    0.091307] usbcore: registered new device driver usb
[    0.091446] usb_phy_generic usbphy: dummy supplies not allowed for exclusive requests
[    0.092222] pps_core: LinuxPPS API ver. 1 registered
[    0.092235] pps_core: Software ver. 5.3.6 - Copyright 2005-2007 Rodolfo Giometti <giometti@linux.it>
[    0.092267] PTP clock support registered
[    0.092403] EDAC MC: Ver: 3.0.0
[    0.094825] stratix10-svc soc:firmware:svc: Failed to get IRQ, falling back to polling mode
[    0.094963] Intel Service Layer Driver Initialized
[    0.095146] scmi_core: SCMI protocol bus registered
[    0.095774] FPGA manager framework
[    0.095889] Advanced Linux Sound Architecture Driver Initialized.
[    0.097067] vgaarb: loaded
[    0.097570] clocksource: Switched to clocksource arch_sys_counter
[    0.097881] VFS: Disk quotas dquot_6.6.0
[    0.097923] VFS: Dquot-cache hash table entries: 512 (order 0, 4096 bytes)
[    0.098142] pnp: PnP ACPI: disabled
[    0.104414] NET: Registered PF_INET protocol family
[    0.104629] IP idents hash table entries: 32768 (order: 6, 262144 bytes, linear)
[    0.106263] tcp_listen_portaddr_hash hash table entries: 1024 (order: 2, 16384 bytes, linear)
[    0.106314] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.106339] TCP established hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.106507] TCP bind hash table entries: 16384 (order: 7, 524288 bytes, linear)
[    0.107141] TCP: Hash tables configured (established 16384 bind 16384)
[    0.107281] UDP hash table entries: 1024 (order: 3, 32768 bytes, linear)
[    0.107336] UDP-Lite hash table entries: 1024 (order: 3, 32768 bytes, linear)
[    0.107516] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.107951] RPC: Registered named UNIX socket transport module.
[    0.107966] RPC: Registered udp transport module.
[    0.107978] RPC: Registered tcp transport module.
[    0.107988] RPC: Registered tcp-with-tls transport module.
[    0.107999] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    0.108028] PCI: CLS 0 bytes, default 64
[    0.108552] kvm [1]: IPA Size Limit: 40 bits
[    0.110902] kvm [1]: Hyp mode initialized successfully
[    0.112466] Initialise system trusted keyrings
[    0.112636] workingset: timestamp_bits=42 max_order=19 bucket_order=0
[    0.113018] squashfs: version 4.0 (2009/01/31) Phillip Lougher
[    0.113267] NFS: Registering the id_resolver key type
[    0.113304] Key type id_resolver registered
[    0.113317] Key type id_legacy registered
[    0.113347] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
[    0.113363] nfs4flexfilelayout_init: NFSv4 Flexfile Layout Driver Registering...
[    0.113482] 9p: Installing v9fs 9p2000 file system support
[    0.148309] Key type asymmetric registered
[    0.148325] Asymmetric key parser 'x509' registered
[    0.148393] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 245)
[    0.148413] io scheduler mq-deadline registered
[    0.148425] io scheduler kyber registered
[    0.148469] io scheduler bfq registered
[    0.154934] pinctrl-single ffd13000.pinctrl: 40 pins, size 160
[    0.155130] pinctrl-single ffd13100.pinconf: 8 pins, size 32
[    0.160189] altera-pcie 90100000.pcie: host bridge /soc/bridge@80000000/pcie@200000000 ranges:
[    0.160249] altera-pcie 90100000.pcie:      MEM 0x0090100000..0x009fffffff -> 0x0000100000
[    0.160726] altera-pcie 90100000.pcie: PCI host bridge to bus 0000:00
[    0.160747] pci_bus 0000:00: root bus resource [bus 00-ff]
[    0.160769] pci_bus 0000:00: root bus resource [mem 0x90100000-0x9fffffff] (bus address [0x00100000-0x0fffffff])
[    0.160861] pci 0000:00:00.0: [1172:0000] type 01 class 0x060400
[    0.161151] pci 0000:00:00.0: PME# supported from D0 D3hot
[    0.162467] pci 0000:00:00.0: bridge configuration invalid ([bus 00-00]), reconfiguring
[    0.162677] pci 0000:01:00.0: [15b7:5042] type 00 class 0x010802
[    0.162769] pci 0000:01:00.0: reg 0x10: [mem 0x00000000-0x00003fff 64bit]
[    0.163961] pci_bus 0000:01: busn_res: [bus 01-ff] end is updated to 01
[    0.164012] pci 0000:00:00.0: BAR 14: assigned [mem 0x90100000-0x901fffff]
[    0.164034] pci 0000:01:00.0: BAR 0: assigned [mem 0x90100000-0x90103fff 64bit]
[    0.164088] pci 0000:00:00.0: PCI bridge to [bus 01]
[    0.164106] pci 0000:00:00.0:   bridge window [mem 0x90100000-0x901fffff]
[    0.164224] pcieport 0000:00:00.0: enabling device (0000 -> 0002)
[    0.165713] EINJ: ACPI disabled.
[    0.190743] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
[    0.194129] ffc02000.serial: ttyS0 at MMIO 0xffc02000 (irq = 19, base_baud = 6250000) is a 16550A
[    0.194238] printk: console [ttyS0] enabled
[    0.348361] SuperH (H)SCI(F) driver initialized
[    0.349469] msm_serial: driver initialized
[    0.350732] STM32 USART driver initialized
[    0.357902] loop: module loaded
[    0.359596] megasas: 07.725.01.00-rc1
[    0.361694] nvme nvme0: pci function 0000:01:00.0
[    0.362376] nvme 0000:01:00.0: enabling device (0000 -> 0002)
[    0.364003] nand: device found, Manufacturer ID: 0x2c, Chip ID: 0xac
[    0.364841] nand: Micron MT29F4G08ABBDAH4
[    0.365372] nand: 512 MiB, SLC, erase size: 128 KiB, page size: 2048, OOB size: 64
[    0.366991] Bad block table found at page 262080, version 0x01
[    0.368384] Bad block table found at page 262016, version 0x01
[    0.370281] 2 fixed-partitions partitions found on MTD device denali-nand
[    0.371186] Creating 2 MTD partitions on "denali-nand":
[    0.371879] 0x000000000000-0x000000200000 : "u-boot"
[    0.374038] 0x000000200000-0x000020000000 : "root"
[    0.376152] nvme nvme0: allocated 32 MiB host memory buffer.
[    0.379810] nvme nvme0: 4/0/0 default/read/poll queues
[    0.384018] tun: Universal TUN/TAP device driver, 1.6
[    0.385975] thunder_xcv, ver 1.0
[    0.386472]  nvme0n1: p1
[    0.386497] thunder_bgx, ver 1.0
[    0.387273] nicpf, ver 1.0
[    0.388837] hns3: Hisilicon Ethernet Network Driver for Hip08 Family - version
[    0.389811] hns3: Copyright (c) 2017 Huawei Corporation.
[    0.390549] hclge is initializing
[    0.391058] e1000: Intel(R) PRO/1000 Network Driver
[    0.391702] e1000: Copyright (c) 1999-2006 Intel Corporation.
[    0.392485] e1000e: Intel(R) PRO/1000 Network Driver
[    0.393140] e1000e: Copyright(c) 1999 - 2015 Intel Corporation.
[    0.393957] igb: Intel(R) Gigabit Ethernet Network Driver
[    0.394668] igb: Copyright (c) 2007-2014 Intel Corporation.
[    0.395425] igbvf: Intel(R) Gigabit Virtual Function Network Driver
[    0.396250] igbvf: Copyright (c) 2009 - 2012 Intel Corporation.
[    0.397333] sky2: driver version 1.30
[    0.399486] socfpga-dwmac ff804000.ethernet: IRQ eth_wake_irq not found
[    0.400362] socfpga-dwmac ff804000.ethernet: IRQ eth_lpi not found
[    0.401644] socfpga-dwmac ff804000.ethernet: User ID: 0x11, Synopsys ID: 0x37
[    0.402597] socfpga-dwmac ff804000.ethernet: 	DWMAC1000
[    0.403290] socfpga-dwmac ff804000.ethernet: DMA HW capability register supported
[    0.404277] socfpga-dwmac ff804000.ethernet: RX Checksum Offload Engine supported
[    0.405261] socfpga-dwmac ff804000.ethernet: COE Type 2
[    0.405966] socfpga-dwmac ff804000.ethernet: TX Checksum insertion supported
[    0.406893] socfpga-dwmac ff804000.ethernet: Enhanced/Alternate descriptors
[    0.407808] socfpga-dwmac ff804000.ethernet: Enabled extended descriptors
[    0.408700] socfpga-dwmac ff804000.ethernet: Ring mode enabled
[    0.409468] socfpga-dwmac ff804000.ethernet: Enable RX Mitigation via HW Watchdog Timer
[    0.410541] socfpga-dwmac ff804000.ethernet: device MAC address 46:47:7b:c2:70:d7
[    0.412281] mdio_bus stmmac-2: MDIO device at address 4 is missing.
[    0.416394] dwc2 ffb00000.usb: supply vusb_d not found, using dummy regulator
[    0.417477] dwc2 ffb00000.usb: supply vusb_a not found, using dummy regulator
[    0.418700] dwc2 ffb00000.usb: Bad value for GSNPSID: 0x00000000
[    0.421289] usbcore: registered new interface driver usb-storage
[    0.425071] i2c_dev: i2c /dev entries driver
[    0.434070] sdhci: Secure Digital Host Controller Interface driver
[    0.434912] sdhci: Copyright(c) Pierre Ossman
[    0.436220] Synopsys Designware Multimedia Card Interface Driver
[    0.438008] sdhci-pltfm: SDHCI platform and OF driver helper
[    0.440822] ledtrig-cpu: registered to indicate activity on CPUs
[    0.443221] SMCCC: SOC_ID: ARCH_SOC_ID not implemented, skipping ....
[    0.445029] usbcore: registered new interface driver usbhid
[    0.445793] usbhid: USB HID core driver
[    0.449931] hw perfevents: enabled with armv8_pmuv3 PMU driver, 7 counters available
[    0.456310] NET: Registered PF_PACKET protocol family
[    0.457109] 9pnet: Installing 9P2000 support
[    0.457789] Key type dns_resolver registered
[    0.468902] registered taskstats version 1
[    0.469859] Loading compiled-in X.509 certificates
[    0.486108] dma-pl330 ffda0000.dma-controller: Loaded driver for PL330 DMAC-341330
[    0.487165] dma-pl330 ffda0000.dma-controller: 	DBUFF-512x8bytes Num_Chans-8 Num_Peri-32 Num_Events-8
[    0.494668] ubi0: attaching mtd1
[    1.069582] random: crng init done
[    1.326971] ubi0: scanning is finished
[    1.332548] ubi0 warning: ubi_eba_init: cannot reserve enough PEBs for bad PEB handling, reserved 33, need 76
[    1.335387] ubi0: attached mtd1 (name "root", size 510 MiB)
[    1.336128] ubi0: PEB size: 131072 bytes (128 KiB), LEB size: 126976 bytes
[    1.337034] ubi0: min./max. I/O unit sizes: 2048/2048, sub-page size 2048
[    1.337940] ubi0: VID header offset: 2048 (aligned 2048), data offset: 4096
[    1.338855] ubi0: good PEBs: 4076, bad PEBs: 4, corrupted PEBs: 0
[    1.339658] ubi0: user volume: 5, internal volumes: 1, max. volumes count: 128
[    1.340608] ubi0: max/mean erase counter: 1/0, WL threshold: 4096, image sequence number: 1663307860
[    1.341815] ubi0: available PEBs: 0, total reserved PEBs: 4076, PEBs reserved for bad PEB handling: 33
[    1.343047] ubi0: background thread "ubi_bgt0d" started, PID 69
[    1.343945] of_cfs_init
[    1.344325] of_cfs_init: OK
[    1.344841] clk: Disabling unused clocks
[    1.345434] ALSA device list:
[    1.345844]   No soundcards found.
[    1.346594] dw-apb-uart ffc02000.serial: forbid DMA for kernel console
[    1.348132] UBIFS (ubi0:4): Mounting in unauthenticated mode
[    1.348995] UBIFS (ubi0:4): background thread "ubifs_bgt0_4" started, PID 70
[    1.362048] UBIFS (ubi0:4): start fixing up free space
[   22.124679] UBIFS (ubi0:4): free space fixup complete
[   22.134220] UBIFS (ubi0:4): UBIFS: mounted UBI device 0, volume 4, name "rootfs"
[   22.135199] UBIFS (ubi0:4): LEB size: 126976 bytes (124 KiB), min./max. I/O unit sizes: 2048 bytes/2048 bytes
[   22.136500] UBIFS (ubi0:4): FS size: 485175296 bytes (462 MiB, 3821 LEBs), max 4000 LEBs, journal size 9023488 bytes (8 MiB, 72 LEBs)
[   22.138087] UBIFS (ubi0:4): reserved for root: 0 bytes (0 KiB)
[   22.138856] UBIFS (ubi0:4): media format: w4/r0 (latest is w5/r0), UUID 8986B57B-64D4-4122-95CB-93A962A12C22, small LPT model
[   22.141238] VFS: Mounted root (ubifs filesystem) on device 0:21.
[   22.142780] devtmpfs: mounted
[   22.144298] Freeing unused kernel memory: 2688K
[   22.145044] Run /sbin/init as init process
INIT: version 3.14 booting
 Inside mountall.sh
Do you want to run filesystem check on /dev/nvme0n1p1? (yes/no): Proceeding without running filesystem check.
 mountall.sh: tsi_install
TSI DIR -  /usr/bin/tsi/Ver1.1 ModulePath =/usr/bin/tsi/Ver1.1/kern_mod/
TSI Software install started..
u-dma-buf.ko
Loading u-dma-buf.ko...
[   27.590152] u_dma_buf: loading out-of-tree module taints kernel.
Mounting SSD drive on /tsi
[   27.593307] u-dma-buf udmabuf@0: assigned reserved memory node svcbuffer@1
[   27.647519] EXT2-fs (nvme0n1p1): warning: mounting unchecked fs, running e2fsck is recommended
tsi-sw/
tsi-sw/ReleaseNotes
tsi-sw/libatomic.so.1
tsi-sw/tsi_txe_xos.blob
tsi-sw/br_netfilter.ko
tsi-sw/sys-diagtool
tsi-sw/llama_expected_result.bin
tsi-sw/tsi-ggml-aws-latest.tz
[   28.105941] u-dma-buf udmabuf0: driver version = 4.8.1
[   28.106689] u-dma-buf udmabuf0: major number   = 509
[   28.107347] u-dma-buf udmabuf0: minor number   = 0
[   28.107980] u-dma-buf udmabuf0: phys address   = 0x0000000040000000
[   28.108808] u-dma-buf udmabuf0: buffer size    = 1073741824
[   28.109548] u-dma-buf udmabuf@0: driver installed.
[   28.111003] u-dma-buf udmabuf@1: assigned reserved memory node svcbuffer@2
tsi-sw/llc.ko
tsi-sw/libstdc++.so
tsi-sw/tsi_txe_kernel.bin
tsi-sw/libstdc++.so.6.0.33-gdb.py
tsi-sw/recvFromHost
tsi-sw/stp.ko
tsi-sw/modules.builtin.modinfo
tsi-sw/bridge.ko
tsi-sw/aot-all-tests_aws_latest.tz
tsi-sw/rtlib_aws_latest.tz
[   38.350940] u-dma-buf udmabuf1: driver version = 4.8.1
[   38.351685] u-dma-buf udmabuf1: major number   = 509
[   38.352342] u-dma-buf udmabuf1: minor number   = 1
[   38.352975] u-dma-buf udmabuf1: phys address   = 0x0000002080000000
[   38.353812] u-dma-buf udmabuf1: buffer size    = 2147483648
[   38.354552] u-dma-buf udmabuf@1: driver installed.
tsi-sw/modules.builtin
tsi-sw/vecadd_blob_tvu_main.blob
tsi-sw/u-dma-buf.ko
tsi-sw/UAP
tsi-sw/ipv6.ko
tsi-sw/tnApcMgr
tsi-sw/platform_layout.json
tsi-sw/dummy.ko
tsi-sw/run_platform_test.sh
tsi-sw/modules.order
tsi-sw/libstdc++.so.6.0.33
tsi-sw/libstdc++.so.6
tsi-sw/overlay.ko
tsi-sw/libcrypt.so.1
./models/linear/linear.exe
./models/llama/llama.exe
./models/llama_sp/llama_sp.exe
./tests-blob-builder/abs_bfloat16_128/abs_bfloat16_128.exe
./tests-blob-builder/abs_bfloat16_64/abs_bfloat16_64.exe
./tests-blob-builder/abs_float16_128/abs_float16_128.exe
./tests-blob-builder/abs_float16_64/abs_float16_64.exe
./tests-blob-builder/abs_float32_128/abs_float32_128.exe
./tests-blob-builder/abs_float32_64/abs_float32_64.exe
./tests-blob-builder/abs_int8_128/abs_int8_128.exe
./tests-blob-builder/abs_int8_64/abs_int8_64.exe
./tests-blob-builder/add_bfloat16_128/add_bfloat16_128.exe
./tests-blob-builder/add_bfloat16_64/add_bfloat16_64.exe
./tests-blob-builder/add_float16_128/add_float16_128.exe
./tests-blob-builder/add_float16_64/add_float16_64.exe
./tests-blob-builder/add_float32_128/add_float32_128.exe
./tests-blob-builder/add_float32_64/add_float32_64.exe
./tests-blob-builder/add_int8_128/add_int8_128.exe
./tests-blob-builder/add_int8_64/add_int8_64.exe
./tests-blob-builder/exp2_bfloat16_128/exp2_bfloat16_128.exe
./tests-blob-builder/exp2_bfloat16_64/exp2_bfloat16_64.exe
./tests-blob-builder/exp2_float16_128/exp2_float16_128.exe
./tests-blob-builder/exp2_float16_64/exp2_float16_64.exe
./tests-blob-builder/exp2_float32_128/exp2_float32_128.exe
./tests-blob-builder/exp2_float32_64/exp2_float32_64.exe
./tests-blob-builder/inv_bfloat16_128/inv_bfloat16_128.exe
./tests-blob-builder/inv_bfloat16_64/inv_bfloat16_64.exe
./tests-blob-builder/inv_float16_128/inv_float16_128.exe
./tests-blob-builder/inv_float16_64/inv_float16_64.exe
./tests-blob-builder/inv_float32_128/inv_float32_128.exe
./tests-blob-builder/inv_float32_64/inv_float32_64.exe
./tests-blob-builder/max_bfloat16_128/max_bfloat16_128.exe
./tests-blob-builder/max_bfloat16_64/max_bfloat16_64.exe
./tests-blob-builder/max_float16_128/max_float16_128.exe
./tests-blob-builder/max_float16_64/max_float16_64.exe
./tests-blob-builder/max_float32_128/max_float32_128.exe
./tests-blob-builder/max_float32_64/max_float32_64.exe
./tests-blob-builder/mul_bfloat16_128/mul_bfloat16_128.exe
./tests-blob-builder/mul_bfloat16_64/mul_bfloat16_64.exe
./tests-blob-builder/mul_float16_128/mul_float16_128.exe
./tests-blob-builder/mul_float16_64/mul_float16_64.exe
./tests-blob-builder/mul_float32_128/mul_float32_128.exe
./tests-blob-builder/mul_float32_64/mul_float32_64.exe
./tests-blob-builder/neg_bfloat16_128/neg_bfloat16_128.exe
./tests-blob-builder/neg_bfloat16_64/neg_bfloat16_64.exe
./tests-blob-builder/neg_float16_128/neg_float16_128.exe
./tests-blob-builder/neg_float16_64/neg_float16_64.exe
./tests-blob-builder/neg_float32_128/neg_float32_128.exe
./tests-blob-builder/neg_float32_64/neg_float32_64.exe
./tests-blob-builder/neg_int8_128/neg_int8_128.exe
./tests-blob-builder/neg_int8_64/neg_int8_64.exe
./tests-blob-builder/sin_bfloat16_128/sin_bfloat16_128.exe
./tests-blob-builder/sin_bfloat16_64/sin_bfloat16_64.exe
./tests-blob-builder/sin_float16_128/sin_float16_128.exe
./tests-blob-builder/sin_float16_64/sin_float16_64.exe
./tests-blob-builder/sin_float32_128/sin_float32_128.exe
./tests-blob-builder/sin_float32_64/sin_float32_64.exe
./tests-blob-builder/sqrt_bfloat16_128/sqrt_bfloat16_128.exe
./tests-blob-builder/sqrt_bfloat16_64/sqrt_bfloat16_64.exe
./tests-blob-builder/sqrt_float16_128/sqrt_float16_128.exe
./tests-blob-builder/sqrt_float16_64/sqrt_float16_64.exe
./tests-blob-builder/sqrt_float32_128/sqrt_float32_128.exe
./tests-blob-builder/sqrt_float32_64/sqrt_float32_64.exe
./tests-blob-builder/sub_bfloat16_128/sub_bfloat16_128.exe
./tests-blob-builder/sub_bfloat16_64/sub_bfloat16_64.exe
./tests-blob-builder/sub_float16_128/sub_float16_128.exe
./tests-blob-builder/sub_float16_64/sub_float16_64.exe
./tests-blob-builder/sub_float32_128/sub_float32_128.exe
./tests-blob-builder/sub_float32_64/sub_float32_64.exe
./tests-blob-builder/sub_int8_128/sub_int8_128.exe
./tests-blob-builder/sub_int8_64/sub_int8_64.exe
./tests-torch/add/add.exe
./tests-torch/exp/exp.exe
./tests-torch/inv/inv.exe
./tests-torch/mult/mult.exe
./tests-torch/neg/neg.exe
./tests-torch/sigmoid/sigmoid.exe
./tests-torch/sqrt/sqrt.exe
./tests-torch/sub/sub.exe
./_deps/magic_enum-subbuild/CMakeFiles/magic_enum-populate.dir/Labels.json
./_deps/spdlog-subbuild/CMakeFiles/spdlog-populate.dir/Labels.json
./_deps/spdlog-src/scripts/ci_setup_clang.sh
./_deps/spdlog-src/scripts/format.sh
./tests-torch/add/add_compiler_config.json
./tests-torch/add/blobs/txe_blob_0.blob
./tests-torch/add/add.sh
./tests-torch/exp/exp_compiler_config.json
./tests-torch/exp/blobs/txe_blob_0.blob
./tests-torch/exp/exp.sh
./tests-torch/inv/inv_compiler_config.json
./tests-torch/inv/blobs/txe_blob_0.blob
./tests-torch/inv/inv.sh
./tests-torch/mult/mult_compiler_config.json
./tests-torch/mult/blobs/txe_blob_0.blob
./tests-torch/mult/mult.sh
./tests-torch/neg/neg_compiler_config.json
./tests-torch/neg/blobs/txe_blob_0.blob
./tests-torch/neg/neg.sh
./tests-torch/sigmoid/sigmoid_compiler_config.json
./tests-torch/sigmoid/blobs/txe_blob_0.blob
./tests-torch/sigmoid/sigmoid.sh
./tests-torch/sqrt/sqrt_compiler_config.json
./tests-torch/sqrt/blobs/txe_blob_0.blob
./tests-torch/sqrt/sqrt.sh
./tests-torch/sub/sub_compiler_config.json
./tests-torch/sub/blobs/txe_blob_0.blob
./tests-torch/sub/sub.sh
./models/linear/linear_compiler_config.json
./models/linear/blobs/txe_blob_1.blob
./models/linear/blobs/txe_blob_0.blob
./models/linear/linear.sh
./models/llama/llama_compiler_config.json
./models/llama/blobs/txe_blob_12.blob
./models/llama/blobs/txe_blob_11.blob
./models/llama/blobs/txe_blob_10.blob
./models/llama/blobs/txe_blob_9.blob
./models/llama/blobs/txe_blob_8.blob
./models/llama/blobs/txe_blob_7.blob
./models/llama/blobs/txe_blob_6.blob
./models/llama/blobs/txe_blob_5.blob
./models/llama/blobs/txe_blob_4.blob
./models/llama/blobs/txe_blob_3.blob
./models/llama/blobs/txe_blob_2.blob
./models/llama/blobs/txe_blob_1.blob
./models/llama/blobs/txe_blob_0.blob
./models/llama/llama.sh
./models/llama_sp/llama_sp_compiler_config.json
./models/llama_sp/blobs/txe_blob_12.blob
./models/llama_sp/blobs/txe_blob_11.blob
./models/llama_sp/blobs/txe_blob_10.blob
./models/llama_sp/blobs/txe_blob_9.blob
./models/llama_sp/blobs/txe_blob_8.blob
./models/llama_sp/blobs/txe_blob_7.blob
./models/llama_sp/blobs/txe_blob_6.blob
./models/llama_sp/blobs/txe_blob_5.blob
./models/llama_sp/blobs/txe_blob_4.blob
./models/llama_sp/blobs/txe_blob_3.blob
./models/llama_sp/blobs/txe_blob_2.blob
./models/llama_sp/blobs/txe_blob_1.blob
./models/llama_sp/blobs/txe_blob_0.blob
./models/llama_sp/llama_sp.sh
./tests-blob-builder/abs_float32_64/abs_float32_64_config.json
./tests-blob-builder/abs_float32_64/abs_float32_64_compiler_config.json
./tests-blob-builder/abs_float32_64/blobs/abs_blob.blob
./tests-blob-builder/abs_float32_64/abs_float32_64.sh
./tests-blob-builder/exp2_float32_64/exp2_float32_64_config.json
./tests-blob-builder/exp2_float32_64/exp2_float32_64_compiler_config.json
./tests-blob-builder/exp2_float32_64/blobs/exp2_blob.blob
./tests-blob-builder/exp2_float32_64/exp2_float32_64.sh
./tests-blob-builder/inv_float32_64/inv_float32_64_config.json
./tests-blob-builder/inv_float32_64/inv_float32_64_compiler_config.json
./tests-blob-builder/inv_float32_64/blobs/inv_blob.blob
./tests-blob-builder/inv_float32_64/inv_float32_64.sh
./tests-blob-builder/neg_float32_64/neg_float32_64_config.json
./tests-blob-builder/neg_float32_64/neg_float32_64_compiler_config.json
./tests-blob-builder/neg_float32_64/blobs/neg_blob.blob
./tests-blob-builder/neg_float32_64/neg_float32_64.sh
./tests-blob-builder/sin_float32_64/sin_float32_64_config.json
./tests-blob-builder/sin_float32_64/sin_float32_64_compiler_config.json
./tests-blob-builder/sin_float32_64/blobs/sin_blob.blob
./tests-blob-builder/sin_float32_64/sin_float32_64.sh
./tests-blob-builder/sqrt_float32_64/sqrt_float32_64_config.json
./tests-blob-builder/sqrt_float32_64/sqrt_float32_64_compiler_config.json
./tests-blob-builder/sqrt_float32_64/blobs/sqrt_blob.blob
./tests-blob-builder/sqrt_float32_64/sqrt_float32_64.sh
./tests-blob-builder/add_float32_64/add_float32_64_config.json
./tests-blob-builder/add_float32_64/add_float32_64_compiler_config.json
./tests-blob-builder/add_float32_64/blobs/add_blob.blob
./tests-blob-builder/add_float32_64/add_float32_64.sh
./tests-blob-builder/max_float32_64/max_float32_64_config.json
./tests-blob-builder/max_float32_64/max_float32_64_compiler_config.json
./tests-blob-builder/max_float32_64/blobs/max_blob.blob
./tests-blob-builder/max_float32_64/max_float32_64.sh
./tests-blob-builder/mul_float32_64/mul_float32_64_config.json
./tests-blob-builder/mul_float32_64/mul_float32_64_compiler_config.json
./tests-blob-builder/mul_float32_64/blobs/mul_blob.blob
./tests-blob-builder/mul_float32_64/mul_float32_64.sh
./tests-blob-builder/sub_float32_64/sub_float32_64_config.json
./tests-blob-builder/sub_float32_64/sub_float32_64_compiler_config.json
./tests-blob-builder/sub_float32_64/blobs/sub_blob.blob
./tests-blob-builder/sub_float32_64/sub_float32_64.sh
./tests-blob-builder/abs_float32_128/abs_float32_128_config.json
./tests-blob-builder/abs_float32_128/abs_float32_128_compiler_config.json
./tests-blob-builder/abs_float32_128/blobs/abs_blob.blob
./tests-blob-builder/abs_float32_128/abs_float32_128.sh
./tests-blob-builder/exp2_float32_128/exp2_float32_128_config.json
./tests-blob-builder/exp2_float32_128/exp2_float32_128_compiler_config.json
./tests-blob-builder/exp2_float32_128/blobs/exp2_blob.blob
./tests-blob-builder/exp2_float32_128/exp2_float32_128.sh
./tests-blob-builder/inv_float32_128/inv_float32_128_config.json
./tests-blob-builder/inv_float32_128/inv_float32_128_compiler_config.json
./tests-blob-builder/inv_float32_128/blobs/inv_blob.blob
./tests-blob-builder/inv_float32_128/inv_float32_128.sh
./tests-blob-builder/neg_float32_128/neg_float32_128_config.json
./tests-blob-builder/neg_float32_128/neg_float32_128_compiler_config.json
./tests-blob-builder/neg_float32_128/blobs/neg_blob.blob
./tests-blob-builder/neg_float32_128/neg_float32_128.sh
./tests-blob-builder/sin_float32_128/sin_float32_128_config.json
./tests-blob-builder/sin_float32_128/sin_float32_128_compiler_config.json
./tests-blob-builder/sin_float32_128/blobs/sin_blob.blob
./tests-blob-builder/sin_float32_128/sin_float32_128.sh
./tests-blob-builder/sqrt_float32_128/sqrt_float32_128_config.json
./tests-blob-builder/sqrt_float32_128/sqrt_float32_128_compiler_config.json
./tests-blob-builder/sqrt_float32_128/blobs/sqrt_blob.blob
./tests-blob-builder/sqrt_float32_128/sqrt_float32_128.sh
./tests-blob-builder/add_float32_128/add_float32_128_config.json
./tests-blob-builder/add_float32_128/add_float32_128_compiler_config.json
./tests-blob-builder/add_float32_128/blobs/add_blob.blob
./tests-blob-builder/add_float32_128/add_float32_128.sh
./tests-blob-builder/max_float32_128/max_float32_128_config.json
./tests-blob-builder/max_float32_128/max_float32_128_compiler_config.json
./tests-blob-builder/max_float32_128/blobs/max_blob.blob
./tests-blob-builder/max_float32_128/max_float32_128.sh
./tests-blob-builder/mul_float32_128/mul_float32_128_config.json
./tests-blob-builder/mul_float32_128/mul_float32_128_compiler_config.json
./tests-blob-builder/mul_float32_128/blobs/mul_blob.blob
./tests-blob-builder/mul_float32_128/mul_float32_128.sh
./tests-blob-builder/sub_float32_128/sub_float32_128_config.json
./tests-blob-builder/sub_float32_128/sub_float32_128_compiler_config.json
./tests-blob-builder/sub_float32_128/blobs/sub_blob.blob
./tests-blob-builder/sub_float32_128/sub_float32_128.sh
./tests-blob-builder/abs_bfloat16_64/abs_bfloat16_64_config.json
./tests-blob-builder/abs_bfloat16_64/abs_bfloat16_64_compiler_config.json
./tests-blob-builder/abs_bfloat16_64/blobs/abs_blob.blob
./tests-blob-builder/abs_bfloat16_64/abs_bfloat16_64.sh
./tests-blob-builder/exp2_bfloat16_64/exp2_bfloat16_64_config.json
./tests-blob-builder/exp2_bfloat16_64/exp2_bfloat16_64_compiler_config.json
./tests-blob-builder/exp2_bfloat16_64/blobs/exp2_blob.blob
./tests-blob-builder/exp2_bfloat16_64/exp2_bfloat16_64.sh
./tests-blob-builder/inv_bfloat16_64/inv_bfloat16_64_config.json
./tests-blob-builder/inv_bfloat16_64/inv_bfloat16_64_compiler_config.json
./tests-blob-builder/inv_bfloat16_64/blobs/inv_blob.blob
./tests-blob-builder/inv_bfloat16_64/inv_bfloat16_64.sh
./tests-blob-builder/neg_bfloat16_64/neg_bfloat16_64_config.json
./tests-blob-builder/neg_bfloat16_64/neg_bfloat16_64_compiler_config.json
./tests-blob-builder/neg_bfloat16_64/blobs/neg_blob.blob
./tests-blob-builder/neg_bfloat16_64/neg_bfloat16_64.sh
./tests-blob-builder/sin_bfloat16_64/sin_bfloat16_64_config.json
./tests-blob-builder/sin_bfloat16_64/sin_bfloat16_64_compiler_config.json
./tests-blob-builder/sin_bfloat16_64/blobs/sin_blob.blob
./tests-blob-builder/sin_bfloat16_64/sin_bfloat16_64.sh
./tests-blob-builder/sqrt_bfloat16_64/sqrt_bfloat16_64_config.json
./tests-blob-builder/sqrt_bfloat16_64/sqrt_bfloat16_64_compiler_config.json
./tests-blob-builder/sqrt_bfloat16_64/blobs/sqrt_blob.blob
./tests-blob-builder/sqrt_bfloat16_64/sqrt_bfloat16_64.sh
./tests-blob-builder/add_bfloat16_64/add_bfloat16_64_config.json
./tests-blob-builder/add_bfloat16_64/add_bfloat16_64_compiler_config.json
./tests-blob-builder/add_bfloat16_64/blobs/add_blob.blob
./tests-blob-builder/add_bfloat16_64/add_bfloat16_64.sh
./tests-blob-builder/max_bfloat16_64/max_bfloat16_64_config.json
./tests-blob-builder/max_bfloat16_64/max_bfloat16_64_compiler_config.json
./tests-blob-builder/max_bfloat16_64/blobs/max_blob.blob
./tests-blob-builder/max_bfloat16_64/max_bfloat16_64.sh
./tests-blob-builder/mul_bfloat16_64/mul_bfloat16_64_config.json
./tests-blob-builder/mul_bfloat16_64/mul_bfloat16_64_compiler_config.json
./tests-blob-builder/mul_bfloat16_64/blobs/mul_blob.blob
./tests-blob-builder/mul_bfloat16_64/mul_bfloat16_64.sh
./tests-blob-builder/sub_bfloat16_64/sub_bfloat16_64_config.json
./tests-blob-builder/sub_bfloat16_64/sub_bfloat16_64_compiler_config.json
./tests-blob-builder/sub_bfloat16_64/blobs/sub_blob.blob
./tests-blob-builder/sub_bfloat16_64/sub_bfloat16_64.sh
./tests-blob-builder/abs_bfloat16_128/abs_bfloat16_128_config.json
./tests-blob-builder/abs_bfloat16_128/abs_bfloat16_128_compiler_config.json
./tests-blob-builder/abs_bfloat16_128/blobs/abs_blob.blob
./tests-blob-builder/abs_bfloat16_128/abs_bfloat16_128.sh
./tests-blob-builder/exp2_bfloat16_128/exp2_bfloat16_128_config.json
./tests-blob-builder/exp2_bfloat16_128/exp2_bfloat16_128_compiler_config.json
./tests-blob-builder/exp2_bfloat16_128/blobs/exp2_blob.blob
./tests-blob-builder/exp2_bfloat16_128/exp2_bfloat16_128.sh
./tests-blob-builder/inv_bfloat16_128/inv_bfloat16_128_config.json
./tests-blob-builder/inv_bfloat16_128/inv_bfloat16_128_compiler_config.json
./tests-blob-builder/inv_bfloat16_128/blobs/inv_blob.blob
./tests-blob-builder/inv_bfloat16_128/inv_bfloat16_128.sh
./tests-blob-builder/neg_bfloat16_128/neg_bfloat16_128_config.json
./tests-blob-builder/neg_bfloat16_128/neg_bfloat16_128_compiler_config.json
./tests-blob-builder/neg_bfloat16_128/blobs/neg_blob.blob
./tests-blob-builder/neg_bfloat16_128/neg_bfloat16_128.sh
./tests-blob-builder/sin_bfloat16_128/sin_bfloat16_128_config.json
./tests-blob-builder/sin_bfloat16_128/sin_bfloat16_128_compiler_config.json
./tests-blob-builder/sin_bfloat16_128/blobs/sin_blob.blob
./tests-blob-builder/sin_bfloat16_128/sin_bfloat16_128.sh
./tests-blob-builder/sqrt_bfloat16_128/sqrt_bfloat16_128_config.json
./tests-blob-builder/sqrt_bfloat16_128/sqrt_bfloat16_128_compiler_config.json
./tests-blob-builder/sqrt_bfloat16_128/blobs/sqrt_blob.blob
./tests-blob-builder/sqrt_bfloat16_128/sqrt_bfloat16_128.sh
./tests-blob-builder/add_bfloat16_128/add_bfloat16_128_config.json
./tests-blob-builder/add_bfloat16_128/add_bfloat16_128_compiler_config.json
./tests-blob-builder/add_bfloat16_128/blobs/add_blob.blob
./tests-blob-builder/add_bfloat16_128/add_bfloat16_128.sh
./tests-blob-builder/max_bfloat16_128/max_bfloat16_128_config.json
./tests-blob-builder/max_bfloat16_128/max_bfloat16_128_compiler_config.json
./tests-blob-builder/max_bfloat16_128/blobs/max_blob.blob
./tests-blob-builder/max_bfloat16_128/max_bfloat16_128.sh
./tests-blob-builder/mul_bfloat16_128/mul_bfloat16_128_config.json
./tests-blob-builder/mul_bfloat16_128/mul_bfloat16_128_compiler_config.json
./tests-blob-builder/mul_bfloat16_128/blobs/mul_blob.blob
./tests-blob-builder/mul_bfloat16_128/mul_bfloat16_128.sh
./tests-blob-builder/sub_bfloat16_128/sub_bfloat16_128_config.json
./tests-blob-builder/sub_bfloat16_128/sub_bfloat16_128_compiler_config.json
./tests-blob-builder/sub_bfloat16_128/blobs/sub_blob.blob
./tests-blob-builder/sub_bfloat16_128/sub_bfloat16_128.sh
./tests-blob-builder/abs_float16_64/abs_float16_64_config.json
./tests-blob-builder/abs_float16_64/abs_float16_64_compiler_config.json
./tests-blob-builder/abs_float16_64/blobs/abs_blob.blob
./tests-blob-builder/abs_float16_64/abs_float16_64.sh
./tests-blob-builder/exp2_float16_64/exp2_float16_64_config.json
./tests-blob-builder/exp2_float16_64/exp2_float16_64_compiler_config.json
./tests-blob-builder/exp2_float16_64/blobs/exp2_blob.blob
./tests-blob-builder/exp2_float16_64/exp2_float16_64.sh
./tests-blob-builder/inv_float16_64/inv_float16_64_config.json
./tests-blob-builder/inv_float16_64/inv_float16_64_compiler_config.json
./tests-blob-builder/inv_float16_64/blobs/inv_blob.blob
./tests-blob-builder/inv_float16_64/inv_float16_64.sh
./tests-blob-builder/neg_float16_64/neg_float16_64_config.json
./tests-blob-builder/neg_float16_64/neg_float16_64_compiler_config.json
./tests-blob-builder/neg_float16_64/blobs/neg_blob.blob
./tests-blob-builder/neg_float16_64/neg_float16_64.sh
./tests-blob-builder/sin_float16_64/sin_float16_64_config.json
./tests-blob-builder/sin_float16_64/sin_float16_64_compiler_config.json
./tests-blob-builder/sin_float16_64/blobs/sin_blob.blob
./tests-blob-builder/sin_float16_64/sin_float16_64.sh
./tests-blob-builder/sqrt_float16_64/sqrt_float16_64_config.json
./tests-blob-builder/sqrt_float16_64/sqrt_float16_64_compiler_config.json
./tests-blob-builder/sqrt_float16_64/blobs/sqrt_blob.blob
./tests-blob-builder/sqrt_float16_64/sqrt_float16_64.sh
./tests-blob-builder/add_float16_64/add_float16_64_config.json
./tests-blob-builder/add_float16_64/add_float16_64_compiler_config.json
./tests-blob-builder/add_float16_64/blobs/add_blob.blob
./tests-blob-builder/add_float16_64/add_float16_64.sh
./tests-blob-builder/max_float16_64/max_float16_64_config.json
./tests-blob-builder/max_float16_64/max_float16_64_compiler_config.json
./tests-blob-builder/max_float16_64/blobs/max_blob.blob
./tests-blob-builder/max_float16_64/max_float16_64.sh
./tests-blob-builder/mul_float16_64/mul_float16_64_config.json
./tests-blob-builder/mul_float16_64/mul_float16_64_compiler_config.json
./tests-blob-builder/mul_float16_64/blobs/mul_blob.blob
./tests-blob-builder/mul_float16_64/mul_float16_64.sh
./tests-blob-builder/sub_float16_64/sub_float16_64_config.json
./tests-blob-builder/sub_float16_64/sub_float16_64_compiler_config.json
./tests-blob-builder/sub_float16_64/blobs/sub_blob.blob
./tests-blob-builder/sub_float16_64/sub_float16_64.sh
./tests-blob-builder/abs_float16_128/abs_float16_128_config.json
./tests-blob-builder/abs_float16_128/abs_float16_128_compiler_config.json
./tests-blob-builder/abs_float16_128/blobs/abs_blob.blob
./tests-blob-builder/abs_float16_128/abs_float16_128.sh
./tests-blob-builder/exp2_float16_128/exp2_float16_128_config.json
./tests-blob-builder/exp2_float16_128/exp2_float16_128_compiler_config.json
./tests-blob-builder/exp2_float16_128/blobs/exp2_blob.blob
./tests-blob-builder/exp2_float16_128/exp2_float16_128.sh
./tests-blob-builder/inv_float16_128/inv_float16_128_config.json
./tests-blob-builder/inv_float16_128/inv_float16_128_compiler_config.json
./tests-blob-builder/inv_float16_128/blobs/inv_blob.blob
./tests-blob-builder/inv_float16_128/inv_float16_128.sh
./tests-blob-builder/neg_float16_128/neg_float16_128_config.json
./tests-blob-builder/neg_float16_128/neg_float16_128_compiler_config.json
./tests-blob-builder/neg_float16_128/blobs/neg_blob.blob
./tests-blob-builder/neg_float16_128/neg_float16_128.sh
./tests-blob-builder/sin_float16_128/sin_float16_128_config.json
./tests-blob-builder/sin_float16_128/sin_float16_128_compiler_config.json
./tests-blob-builder/sin_float16_128/blobs/sin_blob.blob
./tests-blob-builder/sin_float16_128/sin_float16_128.sh
./tests-blob-builder/sqrt_float16_128/sqrt_float16_128_config.json
./tests-blob-builder/sqrt_float16_128/sqrt_float16_128_compiler_config.json
./tests-blob-builder/sqrt_float16_128/blobs/sqrt_blob.blob
./tests-blob-builder/sqrt_float16_128/sqrt_float16_128.sh
./tests-blob-builder/add_float16_128/add_float16_128_config.json
./tests-blob-builder/add_float16_128/add_float16_128_compiler_config.json
./tests-blob-builder/add_float16_128/blobs/add_blob.blob
./tests-blob-builder/add_float16_128/add_float16_128.sh
./tests-blob-builder/max_float16_128/max_float16_128_config.json
./tests-blob-builder/max_float16_128/max_float16_128_compiler_config.json
./tests-blob-builder/max_float16_128/blobs/max_blob.blob
./tests-blob-builder/max_float16_128/max_float16_128.sh
./tests-blob-builder/mul_float16_128/mul_float16_128_config.json
./tests-blob-builder/mul_float16_128/mul_float16_128_compiler_config.json
./tests-blob-builder/mul_float16_128/blobs/mul_blob.blob
./tests-blob-builder/mul_float16_128/mul_float16_128.sh
./tests-blob-builder/sub_float16_128/sub_float16_128_config.json
./tests-blob-builder/sub_float16_128/sub_float16_128_compiler_config.json
./tests-blob-builder/sub_float16_128/blobs/sub_blob.blob
./tests-blob-builder/sub_float16_128/sub_float16_128.sh
./tests-blob-builder/abs_int8_64/abs_int8_64_config.json
./tests-blob-builder/abs_int8_64/abs_int8_64_compiler_config.json
./tests-blob-builder/abs_int8_64/blobs/abs_blob.blob
./tests-blob-builder/abs_int8_64/abs_int8_64.sh
./tests-blob-builder/neg_int8_64/neg_int8_64_config.json
./tests-blob-builder/neg_int8_64/neg_int8_64_compiler_config.json
./tests-blob-builder/neg_int8_64/blobs/neg_blob.blob
./tests-blob-builder/neg_int8_64/neg_int8_64.sh
./tests-blob-builder/add_int8_64/add_int8_64_config.json
./tests-blob-builder/add_int8_64/add_int8_64_compiler_config.json
./tests-blob-builder/add_int8_64/blobs/add_blob.blob
./tests-blob-builder/add_int8_64/add_int8_64.sh
./tests-blob-builder/sub_int8_64/sub_int8_64_config.json
./tests-blob-builder/sub_int8_64/sub_int8_64_compiler_config.json
./tests-blob-builder/sub_int8_64/blobs/sub_blob.blob
./tests-blob-builder/sub_int8_64/sub_int8_64.sh
./tests-blob-builder/abs_int8_128/abs_int8_128_config.json
./tests-blob-builder/abs_int8_128/abs_int8_128_compiler_config.json
./tests-blob-builder/abs_int8_128/blobs/abs_blob.blob
./tests-blob-builder/abs_int8_128/abs_int8_128.sh
./tests-blob-builder/neg_int8_128/neg_int8_128_config.json
./tests-blob-builder/neg_int8_128/neg_int8_128_compiler_config.json
./tests-blob-builder/neg_int8_128/blobs/neg_blob.blob
./tests-blob-builder/neg_int8_128/neg_int8_128.sh
./tests-blob-builder/add_int8_128/add_int8_128_config.json
./tests-blob-builder/add_int8_128/add_int8_128_compiler_config.json
./tests-blob-builder/add_int8_128/blobs/add_blob.blob
./tests-blob-builder/add_int8_128/add_int8_128.sh
./tests-blob-builder/sub_int8_128/sub_int8_128_config.json
./tests-blob-builder/sub_int8_128/sub_int8_128_compiler_config.json
./tests-blob-builder/sub_int8_128/blobs/sub_blob.blob
./tests-blob-builder/sub_int8_128/sub_int8_128.sh
./compile_commands.json
lib/libsentencepiece.so
lib/libsentencepiece.so.0
lib/libsentencepiece.so.0.0.0
lib/libsentencepiece_train.so
lib/libsentencepiece_train.so.0
lib/libsentencepiece_train.so.0.0.0
lib/libspdlog.so
lib/libspdlog.so.1.15
lib/libspdlog.so.1.15.0
lib/libTsavRTFPGAShimCAPI.so
lib/libTsavRTFPGA.so
lib/libTsavRTFPGA.so.0.4.1
lib/libTsavRTPosix.so
lib/libTsavRTPosix.so.0.4.1
lib/libTSICRAddressUtils.so
lib/libTSICRAddressUtils.so.0.3.7
lib/libTSICRCma.so
lib/libTSICRCma.so.0.3.7
lib/libTSICRComm.so
lib/libTSICRComm.so.0.3.7
lib/libTSICRQueues.so
lib/libTSICRQueues.so.0.3.7
lib/libTSICRQueueUtils.so
lib/libTSICRQueueUtils.so.0.3.7
lib/libTSIRTBlobSlots.so
lib/libTSIRTBlobSlots.so.0.4.1
lib/libTSIRTBlobUtils.so
lib/libTSIRTBlobUtils.so.0.4.1
lib/libTSIRTFloatTypes.so
lib/libTSIRTFloatTypes.so.0.4.1
lib/libTSIRTFPGAShmem.so
lib/libTSIRTFPGAShmem.so.0.4.1
lib/libTSIRTHostUtils.so
lib/libTSIRTHostUtils.so.0.4.1
lib/libTSIRTMemory.so
lib/libTSIRTMemory.so.0.4.1
lib/libTSIRTPosixShmem.so
lib/libTSIRTPosixShmem.so.0.4.1
lib/libTSIRTSafeTensors.so
lib/libTSIRTSafeTensors.so.0.4.1
lib/libTSIRTSharedMemory.so
lib/libTSIRTSharedMemory.so.0.4.1
lib/libTSIRTTXEManagerShimFPGA.so
lib/libTSIRTTXEManagerShimFPGA.so.0.2.0
lib/libTSIRTUtils.so
lib/libTSIRTUtils.so.0.3.7
lib/libTXEPosixSimDeviceLib.so
lib/libTXEPosixSimDeviceLib.so.0.4.1
tsi-ggml/blobs/
tsi-ggml/blobs/txe_add_blob.blob
tsi-ggml/blobs/txe_sub_blob.blob
tsi-ggml/blobs/txe_mult_blob.blob
tsi-ggml/blobs/txe_div_blob.blob
tsi-ggml/blobs/txe_abs_blob.blob
tsi-ggml/blobs/txe_neg_blob.blob
tsi-ggml/blobs/txe_sqrt_blob.blob
tsi-ggml/blobs/txe_inv_blob.blob
tsi-ggml/blobs/txe_sin_blob.blob
tsi-ggml/blobs/txe_sigmoid_blob.blob
tsi-ggml/ggml.sh
tsi-ggml/libggml-base.so
tsi-ggml/libggml-cpu.so
tsi-ggml/libggml.so
tsi-ggml/libggml-tsavorite.so
tsi-ggml/libllama.so
tsi-ggml/llama-cli
tsi-ggml/simple-backend-tsi
PATH: /bin:/usr/lib:/usr/bin:/opt/tsi/:/usr/local/bin:/sbin:/usr/include:/usr/share:/sbin:/bin:/usr/sbin:/usr/bin
 Adding system startup for /etc/init.d/tsi-start.
Starting udev
[   67.464755] udevd[237]: starting version 3.2.14
[   67.522872] udevd[238]: starting eudev-3.2.14
[   67.619717] mtdblock: MTD device 'u-boot' is NAND, please consider using UBI block devices instead.
[   67.620094] mtdblock: MTD device 'root' is NAND, please consider using UBI block devices instead.
hwclock: Cannot access the Hardware Clock via any known method.
hwclock: Use the --verbose option to see the details of our search for an access method.
Fri Mar  9 12:34:56 UTC 2018
hwclock: Cannot access the Hardware Clock via any known method.
hwclock: Use the --verbose option to see the details of our search for an access method.
hwclock: Cannot access the Hardware Clock via any known method.
hwclock: Use the --verbose option to see the details of our search for an access method.
INIT: Entering runlevel: 5
Configuring network interfaces... [   83.936664] socfpga-dwmac ff804000.ethernet eth0: Register MEM_TYPE_PAGE_POOL RxQ-0
[   83.939080] socfpga-dwmac ff804000.ethernet eth0: __stmmac_open: Cannot attach to PHY (error: -19)
ip: SIOCSIFFLAGS: No such device
ip: SIOCGIFFLAGS: No such device
Starting syslogd/klogd: done
Directory /usr/bin/tsi/v0.1.1.tsv30_05_24_2025/bin exists.
Do you want to run tnApcMgr? (yes/no)
yes
Started tnApcMgr...
[2018-03-09 12:35:02.839894] 422:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_main.c:425> APC Init started
[2018-03-09 12:35:02.840132] 422:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_main.c:426> Logger initialized successfully.
[2018-03-09 12:35:02.842201] 423:422 [error]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/common/tsi_db_api.c:1959> DB Persistent file doesnt exist for reading

[2018-03-09 12:35:02.842507] 423:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/common/tsi_db_api.c:2434> DB After parsing  total node count 1, Package_count 1, chiplet_count 1, agent_count 1
[2018-03-09 12:35:02.843660] 423:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_main.c:71> Database initialized successfully
[2018-03-09 12:35:02.843811] 423:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_main.c:76> RSM message queue created successfully.
[2018-03-09 12:35:02.844541] 423:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_main.c:83> RSM message queue pop thread created successfully.
[2018-03-09 12:35:03.841988] 422:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_main.c:155> RSM fork process successfully initialized
[2018-03-09 12:35:03.843187] 425:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/unittest_main/clilib_server/clilib_prompt.c:814> CLI server listening on port 8000
[2018-03-09 12:35:04.842597] 422:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_main.c:141> CLI fork process successfully initialized
[2018-03-09 12:35:04.850137] 423:424 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:233> DB available TXE count request processed successfully.
[2018-03-09 12:35:04.850239] 422:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_main.c:293> Total TXE count = 1, Available TXE count = 1
[2018-03-09 12:35:04.850506] 423:424 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:211> DB agent count request processed successfully.
[2018-03-09 12:35:04.850543] 422:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_main.c:324> txe manager count = 1, total_txe_count = 1
[2018-03-09 12:35:04.852016] 423:424 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:288> DB agent details request processed successfully.
[2018-03-09 12:35:04.852189] 423:424 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:314> DB agent status update request processed successfully.
[2018-03-09 12:35:04.852249] 427:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_txe_mgr.c:758> Agent ID: 10000 successfully updated to 'Initialization in Progress' state
[2018-03-09 12:35:04.853741] 427:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_txe_mgr.c:535> Setup TXE {0, 0, 0}
[2018-03-09 12:35:04.853765] 427:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_txe_mgr.c:538> mmap() memory for chipletID:0.
[2018-03-09 12:35:05.856217] 427:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_txe_mgr.c:638> TXE status for TXE:0 is 1
[2018-03-09 12:35:05.856626] 423:424 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:314> DB agent status update request processed successfully.
[2018-03-09 12:35:05.856667] 427:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_txe_mgr.c:823> Agent ID: 10000 is now in 'Ready' state
[2018-03-09 12:35:05.856800] 423:424 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/rsm_mgr/rsm_process_req.c:342> DB agent base pointer request processed successfully.
[2018-03-09 12:35:05.856832] 427:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_txe_mgr.c:843> Agent ID: 10000 base pointer successfully updated in DB
[2018-03-09 12:35:05.856855] 427:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_txe_mgr.c:844> Agent ID: 10000 is ready for use
[2018-03-09 12:35:09.851620] 422:422 [ info]  :: </proj/work/atrivedi/workspace/05_27_2025/tsi_yocto_workspace/tsi-apc-manager/platform/apc_mgr/apc_main.c:77>

Total number of TXE Managers: 1
====================================================================
 TXE Manager PID            Status
====================================================================
             427                 0
====================================================================

Poky (Yocto Project Reference Distro) 5.2.1 agilex7_dk_si_agf014ea ttyS0

agilex7_dk_si_agf014ea login: root

       Tsavorite Scalable Intelligence

    |||||||||||||||||||||||||||||||||||||
    |||||||||||||||||||||||||||||||||||||
    ||||||                          |||||
    ||||||                          |||||
    |||||||||||||||||   |||||       |||||
    |||||||||||||||||   |||||       |||||
               ||||||   |||||
    ||||||     ||||||   |||||      ||||||
     ||||||||  ||||||   |||||   ||||||||
       ||||||||||||||   ||||||||||||||
          |||||||||||   ||||||||||||
            |||||||||   ||||||||||
              |||||||   ||||||||
                |||||   |||||
                  |||   |||
                        |

root@agilex7_dk_si_agf014ea:~#
root@agilex7_dk_si_agf014ea:~#