### PR TITLE
@FIR-1325: Update linux command line to pass huge page configuration

### DIFF
--- a/include/configs/socfpga_soc64_common.h
+++ b/include/configs/socfpga_soc64_common.h
@@ -169,6 +169,7 @@
 	"scriptfile=boot.scr\0" \
 	"nandroot=ubi0:rootfs\0" \
 	"nandfitboot=setenv bootargs " CONFIG_BOOTARGS \
+			" hugepagesz=2M hugepages=20 " \
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
 	"nandfitload=enable bridge 7; ubi part root; ubi readvol ${loadaddr} kernel\0" \
@@ -210,6 +211,7 @@
 	"scriptfile=u-boot.scr\0" \
 	"nandroot=ubi0:rootfs\0" \
 	"nandfitboot=setenv bootargs " CONFIG_BOOTARGS \
+			" hugepagesz=2M hugepages=20" \
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
 	"nandfitload=bridge enable 7; ubi part root; ubi readvol ${loadaddr} kernel\0" \
@@ -278,6 +280,7 @@
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"booti ${loadaddr} - ${fdt_addr}\0" \
 	"nandfitboot=setenv bootargs " CONFIG_BOOTARGS \
+			" hugepagesz=2M hugepages=20" \
 			" root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; " \
 			"bootm ${loadaddr}\0" \
 	"nandfitload=enable bridge 7; ubi part root; ubi readvol ${loadaddr} kernel\0" \


### PR DESCRIPTION
This change adds hge page config to linux boot command line The test results are asl follows
==============
u-boot configs
==============
SOCFPGA_AGILEX7 # printenv
arch=arm
baudrate=921600
board=agilex7-socdk
board_id=0
...
...
nandfitboot=setenv bootargs earlycon panic=-1 hugepagesz=2M hugepages=20 root=${nandroot} rw rootwait rootfstype=ubifs ubi.mtd=1; bootm ${loadaddr} nandfitload=bridge enable 7; ubi part root; ubi readvol ${loadaddr} kernel nandroot=ubi0:rootfs
qspi_clock=<0x00000000>
qspibootimageaddr=0x02120000
qspiscriptaddr=0x02110000
rsu_log_level=7
...

===============
Linux boot command line
===============
agilex7_dk_si_agf014eb login: root

       Tsavorite Scalable Intelligence

    |||||||||||||||||||||||||||||||||||||
    |||||||||||||||||||||||||||||||||||||
    ||||||                          |||||
    ||||||                          |||||
    |||||||||||||||||   |||||       |||||
    |||||||||||||||||   |||||       |||||
               ||||||   |||||
    ||||||     ||||||   |||||      ||||||
     ||||||||  ||||||   |||||   ||||||||
       ||||||||||||||   ||||||||||||||
          |||||||||||   ||||||||||||
            |||||||||   ||||||||||
              |||||||   ||||||||
                |||||   |||||
                  |||   |||
                        |

root@agilex7_dk_si_agf014eb:~#
root@agilex7_dk_si_agf014eb:~# cat /proc/cmdline
earlycon panic=-1 hugepagesz=2M hugepages=20 root=ubi0:rootfs rw rootwait rootfstype=ubifs ubi.mtd=1 root@agilex7_dk_si_agf014eb:~#
root@agilex7_dk_si_agf014eb:~# cat /proc/sys/vm/nr_hugepages
20
root@agilex7_dk_si_agf014eb:~# 
root@agilex7_dk_si_agf014eb:~# grep Huge /proc/meminfo
AnonHugePages:         0 kB
ShmemHugePages:        0 kB
FileHugePages:         0 kB
HugePages_Total:      20
HugePages_Free:       19
HugePages_Rsvd:        0
HugePages_Surp:        0
Hugepagesize:       2048 kB
Hugetlb:           40960 kB
root@agilex7_dk_si_agf014eb:~# 

Terminating...
Thanks for using picocom